### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-#CtrBootManager
+# CtrBootManager
 
 CtrBootManager is a boot manager for some 3DS homebrew applications, like HBL and CFW.
 
-##Dependencies
+## Dependencies
 - devkitpro-4.5 at least (ctrulib-1.0 at least)
 - libconfig in portlibs (tried with v1.5)
 
-##Building
-###The recommended way:
+## Building
+### The recommended way:
  1. `mkdir build/`
  2. `cd build/`
  3. `cmake -DCMAKE_TOOLCHAIN_FILE=../DevkitArm3DS.cmake ../`
@@ -15,8 +15,8 @@ CtrBootManager is a boot manager for some 3DS homebrew applications, like HBL an
 
 Binaries should now be in the `build` folder.
 
-##Credits
-###For contributions to hb_menu:
+## Credits
+### For contributions to hb_menu:
  * smea : code
  * GEMISIS : code
  * fincs : code
@@ -25,6 +25,6 @@ Binaries should now be in the `build` folder.
  * Arkhandar : graphics
  * dotjasp : graphics (regionfree icon)
 
-###Other credits:
+### Other credits:
 Readme by gemarcano
 This project also uses [Brahma](https://github.com/patois/Brahma). See its repository for its credits.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
